### PR TITLE
Permite filtrar documento por serie

### DIFF
--- a/src/rn/MdWsSeiDocumentoRN.php
+++ b/src/rn/MdWsSeiDocumentoRN.php
@@ -581,6 +581,9 @@ class MdWsSeiDocumentoRN extends DocumentoRN
           $documentoDTOConsulta->retStrStaEstadoProtocolo();
           $documentoDTOConsulta->retNumIdTipoConferencia();
           $documentoDTOConsulta->retArrObjAssinaturaDTO();
+          if ($documentoDTOParam->isSetNumIdSerie()) {
+            $documentoDTOConsulta->setNumIdSerie($documentoDTOParam->getNumIdSerie());
+          }
           $documentoDTOConsulta->setDblIdDocumento(array_keys(InfraArray::indexarArrInfraDTO($ret, 'IdProtocolo2')), InfraDTO::$OPER_IN);
           $documentoRN = new DocumentoRN();
           /** Chama o componente SEI para retorno das informações dos documentos do processo */
@@ -600,6 +603,9 @@ class MdWsSeiDocumentoRN extends DocumentoRN
         /** @var RelProtocoloProtocoloDTO $relProtocoloProtocoloDTO */
       foreach ($ret as $relProtocoloProtocoloDTO) {
           $documentoDTO = $arrDocumentos[$relProtocoloProtocoloDTO->getDblIdProtocolo2()];
+          if (is_null($documentoDTO)) {
+            continue;
+          }
           $mimetype = null;
           $nomeAnexo = null;
           $informacao = null;

--- a/src/versao/v2/MdWsSeiServicosV2.php
+++ b/src/versao/v2/MdWsSeiServicosV2.php
@@ -621,6 +621,9 @@ class MdWsSeiServicosV2 extends MdWsSeiVersaoServicos
                 if ($request->getParam('limit')) {
                     $dto->setNumMaxRegistrosRetorno($request->getParam('limit'));
                 }
+                if ($request->getParam('serie')) {
+                    $dto->setNumIdSerie($request->getParam('serie'));
+                }
                 if (is_null($request->getParam('start'))) {
                     $dto->setNumPaginaAtual(0);
                 } else {


### PR DESCRIPTION
Permite passar o filtro "serie" como parâmetro na consulta do endpoint GET /documento/listar/{procedimento}.

Desta forma a API retorna apenas os documentos de um tipo (serie) específico.